### PR TITLE
Bugfixes: autoMode, handling spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ function createRequest() {
 }
 ```
 
-Now you can just run `createRequest first-last` and it will poop out the request url for you!
+Now you can just run `createRequest "First Last"` and it will poop out the request url for you!

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Use this script to quickly create a dropbox file request for technical interview
 ```
  # File Request Creator
 function createRequest() {
-  python /path/to/create_request.py "$1"
+  python /path/to/create_request.py "${1}"
 }
 ```
 

--- a/create_request.py
+++ b/create_request.py
@@ -2,16 +2,17 @@ import dropbox
 import os
 import sys
 
-MY_ACCESS_TOKEN=os.environ['DROPBOX_ACCESS_TOKEN'];
+MY_ACCESS_TOKEN=os.environ['DROPBOX_ACCESS_TOKEN']
 INTERVIEW_DIRECTORY='/Everyone/Interviewing/interviews'
 
 dbx = dropbox.Dropbox(MY_ACCESS_TOKEN)
 
-interviewee = sys.argv[1];
-autoMode = sys.argv[1] is not None
+autoMode = len(sys.argv) > 1
 
 if not autoMode:
     interviewee = input("What is the name of the candidate?\n")
+else:
+    interviewee = sys.argv[1]
 
 folder_name = interviewee.replace(' ', '-').lower()
 file_request_title = "Technical Interview - {}".format(interviewee)


### PR DESCRIPTION
- Don't try to access `sys.argv[1]` if it doesn't exist (i.e., if we're running autoMode)
- Allow spaces in the candidate name: `createRequest "Firstname Lastname"` will now create a folder called `firstname-lastname` and a corresponding request titled `Technical Interview - Firstname Lastname` (before,`Lastname` would have been left off the request title)